### PR TITLE
Add config variable for test_mode

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -30,6 +30,8 @@ You need to configure the gem with your own Payson credentials through the <tt>P
 
 Please note that if <tt>config.api_user_id</tt> is set to 4, the client will go into test mode. Valid test access credentials could be found in {documentation}[https://api.payson.se/#Testing/sandbox].
 
+For more detailed testing you may create your own test agent for use in the test environment. Use <tt>config.test_mode = true</tt> 
+
 === Initiating a payment
 
   return_url = 'http://localhost/payson/success'

--- a/lib/payson_api/config.rb
+++ b/lib/payson_api/config.rb
@@ -35,7 +35,7 @@ module PaysonAPI
   end
 
   class Configuration
-    attr_accessor :api_user_id, :api_password
+    attr_accessor :api_user_id, :api_password, :test_mode
   end
 
   configure do |config|
@@ -44,7 +44,7 @@ module PaysonAPI
   end
 
   def test?
-    @config.api_user_id == '4'
+    @config.test_mode || @config.api_user_id == '4'
   end
 
 end

--- a/test/integration/config_test.rb
+++ b/test/integration/config_test.rb
@@ -12,4 +12,12 @@ class ConfigTest < Test::Unit::TestCase
     assert_equal CONFIG[:api_password], PaysonAPI.config.api_password
     assert PaysonAPI.test?
   end
+
+  def test_setting_test_mode
+    PaysonAPI.config.api_user_id = '123'
+    assert !PaysonAPI.test?
+    PaysonAPI.config.test_mode = true
+    assert PaysonAPI.test?
+  end
+
 end


### PR DESCRIPTION
If you have your [own test agent](https://test-www.payson.se/myaccount/testaccount/create/) you should be able to enable test mode.