### PR TITLE
Fix nil issue when a key has no corresponding value

### DIFF
--- a/lib/payson_api/v1/client.rb
+++ b/lib/payson_api/v1/client.rb
@@ -48,7 +48,9 @@ module PaysonAPI
         {}.tap do |hash|
           params.split('&').each do |param|
             key, val = param.split('=')
-            hash[key] = URI.decode_www_form_component(val)
+            unless val.nil?
+              hash[key] = URI.decode_www_form_component(val)
+            end
           end
         end
       end

--- a/lib/payson_api/version.rb
+++ b/lib/payson_api/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PaysonAPI
-  VERSION = '1.0.2'
+  VERSION = '1.0.2.1'
 end


### PR DESCRIPTION
Fixes nil issue when there are keys that have no corresponding values.
(eg. `"foo=&bar=baz"` would crash params_to_hash)